### PR TITLE
Refactor stores and generalize codebase

### DIFF
--- a/js/js/sketchpad/editors/design/Tools.tsx
+++ b/js/js/sketchpad/editors/design/Tools.tsx
@@ -55,9 +55,10 @@ const getDesignTools = (t: (key: string) => string): ToolDefinition[] => [
 export const ToolsToggleGroup: FC = () => {
   const { t } = useTranslation();
   const { kit, design } = useParams();
-  const editor = useDesignEditorSafe((s) => s, kit && design ? { kit, design } : undefined);
-  const { setActiveTool } = useDesignEditorCommands(kit && design ? { kit, design } : undefined);
+  if (!kit || !design) return null;
+  const editor = useDesignEditor((s) => s, { kit, design });
+  const { setActiveTool } = useDesignEditorCommands({ kit, design });
   const activeTool = editor?.activeTool || ToolType.SELECTION_NORMAL;
-  if (!editor) return <></>;
+  if (!editor) return null;
   return <ToolGroup tools={getDesignTools(t)} activeTool={activeTool} onToolChange={setActiveTool} level="panel" />;
 };

--- a/js/js/sketchpad/editors/design/panels/Workbench.tsx
+++ b/js/js/sketchpad/editors/design/panels/Workbench.tsx
@@ -197,9 +197,9 @@ export const DesignAvatar: FC<DesignAvatarProps> = ({ designId, design: designPr
   const designScope = useDesignScope();
   const currentDesignFromScope = designScope ? (useDesign() as Design | null) : null;
 
-  const selectionFromScope = useDesignEditorSelectionSafe();
-  const hoverFromScope = useDesignEditorHoverSafe();
-  const commandsFromScope = useDesignEditorCommandsSafe();
+  const selectionFromScope = designScope ? useDesignEditorSelection() : undefined;
+  const hoverFromScope = designScope ? useDesignEditorHover() : undefined;
+  const commandsFromScope = designScope ? useDesignEditorCommands() : undefined;
 
   const isHovered = hoverFromScope?.designs?.includes(design?.guid || "") ?? false;
 

--- a/js/js/sketchpad/editors/design/store.tsx
+++ b/js/js/sketchpad/editors/design/store.tsx
@@ -656,14 +656,6 @@ export function useDesignEditor<T>(selector?: (state: DesignEditorState) => T, i
   return useSyncDeep<DesignEditorState, T>(store as DesignEditorStore, selector ? selector : identitySelector);
 }
 
-export function useDesignEditorSafe<T>(selector?: (state: DesignEditorState) => T, id?: DesignEditorId): T | DesignEditorState | null {
-  try {
-    return useDesignEditor(selector, id);
-  } catch {
-    return null;
-  }
-}
-
 export function useDesignEditorSelection(): DesignEditorSelection {
   return useDesignEditor((s) => s.selection) as DesignEditorSelection;
 }
@@ -696,78 +688,6 @@ export function useDesignEditorDiagramScale(): number | undefined {
 
 export function useDesignEditorHover(): DesignEditorHover | undefined {
   return useDesignEditor((s) => s.hover) as DesignEditorHover | undefined;
-}
-
-export function useDesignEditorSelectionSafe(): DesignEditorSelection | undefined {
-  try {
-    return useDesignEditorSelection();
-  } catch {
-    return undefined;
-  }
-}
-
-export function useDesignEditorHoverSafe(): DesignEditorHover | undefined {
-  try {
-    return useDesignEditorHover();
-  } catch {
-    return undefined;
-  }
-}
-
-export function useDesignEditorCommandsSafe(id?: DesignEditorId) {
-  try {
-    return useDesignEditorCommands(id);
-  } catch {
-    return {
-      startTransaction: () => {},
-      finalizeTransaction: () => {},
-      abortTransaction: () => {},
-      undo: () => {},
-      redo: () => {},
-      selectAll: () => Promise.resolve(),
-      deselectAll: () => Promise.resolve(),
-      selectPiece: () => Promise.resolve(),
-      selectPieces: () => Promise.resolve(),
-      addPieceToSelection: () => Promise.resolve(),
-      removePieceFromSelection: () => Promise.resolve(),
-      selectConnection: () => Promise.resolve(),
-      addConnectionToSelection: () => Promise.resolve(),
-      removeConnectionFromSelection: () => Promise.resolve(),
-      selectPiecePort: () => Promise.resolve(),
-      deselectPiecePort: () => Promise.resolve(),
-      deleteSelected: () => Promise.resolve(),
-      toggleDiagramFullscreen: () => Promise.resolve(),
-      toggleAccesslFullscreen: () => Promise.resolve(),
-      setActiveTool: () => Promise.resolve(),
-      addPiece: () => Promise.resolve(),
-      addPieces: () => Promise.resolve(),
-      removePiece: () => Promise.resolve(),
-      removePieces: () => Promise.resolve(),
-      addConnection: () => Promise.resolve(),
-      addConnections: () => Promise.resolve(),
-      removeConnection: () => Promise.resolve(),
-      removeConnections: () => Promise.resolve(),
-      updatePiece: () => Promise.resolve(),
-      updatePieces: () => Promise.resolve(),
-      updateConnection: () => Promise.resolve(),
-      updateConnections: () => Promise.resolve(),
-      setCamera: () => Promise.resolve(),
-      setDiagramCenter: () => Promise.resolve(),
-      setDiagramScale: () => Promise.resolve(),
-      hoverPiece: () => Promise.resolve(),
-      hoverPieces: () => Promise.resolve(),
-      hoverConnection: () => Promise.resolve(),
-      hoverConnections: () => Promise.resolve(),
-      hoverPort: () => Promise.resolve(),
-      hoverType: () => Promise.resolve(),
-      hoverTypes: () => Promise.resolve(),
-      hoverDesign: () => Promise.resolve(),
-      hoverDesigns: () => Promise.resolve(),
-      clearHover: () => Promise.resolve(),
-      togglePanel: () => {},
-      execute: () => Promise.resolve(),
-    };
-  }
 }
 
 export function useDesignEditorCommands(id?: DesignEditorId) {

--- a/js/js/sketchpad/editors/type/Tools.tsx
+++ b/js/js/sketchpad/editors/type/Tools.tsx
@@ -55,9 +55,10 @@ const getTypeTools = (t: (key: string) => string): ToolDefinition[] => [
 export const ToolsToggleGroup: FC = () => {
   const { t } = useTranslation();
   const { kit, type } = useParams();
-  const editor = useTypeEditorSafe((s) => s, kit && type ? { kit, type } : undefined);
-  const { setActiveTool } = useTypeEditorCommands(kit && type ? { kit, type } : undefined);
+  if (!kit || !type) return null;
+  const editor = useTypeEditor((s) => s, { kit, type });
+  const { setActiveTool } = useTypeEditorCommands({ kit, type });
   const activeTool = editor?.activeTool ?? ToolType.SELECTION_NORMAL;
-  if (!editor) return <></>;
+  if (!editor) return null;
   return <ToolGroup tools={getTypeTools(t)} activeTool={activeTool} onToolChange={setActiveTool} level="panel" />;
 };

--- a/js/js/sketchpad/editors/type/store.tsx
+++ b/js/js/sketchpad/editors/type/store.tsx
@@ -478,13 +478,6 @@ export function useTypeEditor<T>(selector?: (state: TypeEditorState) => T, id?: 
   return useSyncDeep<TypeEditorState, T>(store as TypeEditorStore, selector ? selector : identitySelector);
 }
 
-export function useTypeEditorSafe<T>(selector?: (state: TypeEditorState) => T, id?: TypeEditorId): T | TypeEditorState | null {
-  try {
-    return useTypeEditor(selector, id);
-  } catch {
-    return null;
-  }
-}
 
 export function useTypeEditorSelection(): TypeEditorSelection {
   return useTypeEditor((s) => s.selection) as TypeEditorSelection;

--- a/js/js/sketchpad/kits/store.tsx
+++ b/js/js/sketchpad/kits/store.tsx
@@ -4507,7 +4507,7 @@ export function useFileUrls(): Map<Url, Url> {
   return (useKitStore() as KitStore).fileUrls;
 }
 
-export function useKitCommandsSafe() {
+export function useKitCommands() {
   const store = useSketchpadStore();
   const kitScope = useKitScope();
   const kitGuid = kitScope?.guid;

--- a/js/js/sketchpad/store.tsx
+++ b/js/js/sketchpad/store.tsx
@@ -170,6 +170,19 @@ export function createObserver(yObject: Y.AbstractType<any>, subscribe: Subscrib
 
 // #region Store Hierarchy
 
+export enum StoreStatus {
+  IDLE = "idle",
+  LOADING = "loading",
+  ERROR = "error",
+  READY = "ready",
+}
+
+export interface StoreState<TState> {
+  status: StoreStatus;
+  data?: TState;
+  error?: Error;
+}
+
 export abstract class Store<TState> {
   public readonly guid: Guid;
   public readonly parent: SketchpadStore;
@@ -177,18 +190,35 @@ export abstract class Store<TState> {
   protected readonly transact: Transact;
   protected cache?: TState;
   protected cacheHash?: string;
+  protected status: StoreStatus = StoreStatus.IDLE;
+  protected error?: Error;
 
   constructor(parent: SketchpadStore, yMap: Y.Map<any>, transact: Transact) {
     this.guid = guid();
     this.parent = parent;
     this.yMap = yMap;
     this.transact = transact;
+    this.initialize();
+  }
+
+  protected initialize(): void {
+    try {
+      this.status = StoreStatus.LOADING;
+      this.buildSnapshot();
+      this.status = StoreStatus.READY;
+    } catch (error) {
+      this.status = StoreStatus.ERROR;
+      this.error = error instanceof Error ? error : new Error(String(error));
+    }
   }
 
   protected abstract hash(state: TState): string;
   protected abstract buildSnapshot(): TState;
 
   snapshot(): TState {
+    if (this.status === StoreStatus.ERROR) {
+      throw this.error || new Error("Store is in error state");
+    }
     const currentData = this.buildSnapshot();
     const currentHash = this.hash(currentData);
     if (!this.cache || this.cacheHash !== currentHash) {
@@ -196,6 +226,39 @@ export abstract class Store<TState> {
       this.cacheHash = currentHash;
     }
     return this.cache;
+  }
+
+  getState(): StoreState<TState> {
+    return {
+      status: this.status,
+      data: this.status === StoreStatus.READY ? this.snapshot() : undefined,
+      error: this.error,
+    };
+  }
+
+  isReady(): boolean {
+    return this.status === StoreStatus.READY;
+  }
+
+  isLoading(): boolean {
+    return this.status === StoreStatus.LOADING;
+  }
+
+  isError(): boolean {
+    return this.status === StoreStatus.ERROR;
+  }
+
+  protected handleError(error: unknown, context: string): void {
+    this.status = StoreStatus.ERROR;
+    this.error = error instanceof Error ? error : new Error(`${context}: ${String(error)}`);
+    console.error(`[Store ${this.guid}] ${context}:`, error);
+  }
+
+  protected clearError(): void {
+    this.error = undefined;
+    if (this.status === StoreStatus.ERROR) {
+      this.status = StoreStatus.READY;
+    }
   }
 
   onChanged(subscribe: Subscribe): Unsubscribe {
@@ -632,6 +695,19 @@ export function useSync<TAccessl, TSelected = TAccessl>(store: Synchronizable<TA
 
 export function useSyncDeep<TAccessl, TSelected = TAccessl>(store: Synchronizable<TAccessl> | null, selector?: (state: TAccessl) => TSelected): TAccessl | TSelected | null {
   return useSync(store, selector, true);
+}
+
+export function useSyncWithState<TAccessl, TSelected = TAccessl>(store: (Synchronizable<TAccessl> & Store<TAccessl>) | null, selector?: (state: TAccessl) => TSelected, deep: boolean = false): StoreState<TAccessl | TSelected> {
+  const actualStore = store || (nullStore as unknown as Synchronizable<TAccessl> & Store<TAccessl>);
+  const state = deep ? useSyncExternalStore(actualStore.onChangedDeep.bind(actualStore), actualStore.snapshot.bind(actualStore)) : useSyncExternalStore(actualStore.onChanged.bind(actualStore), actualStore.snapshot.bind(actualStore));
+  if (!store) {
+    return { status: StoreStatus.IDLE, data: null as any };
+  }
+  const storeState = (store as Store<TAccessl>).getState();
+  return {
+    ...storeState,
+    data: storeState.data && selector ? selector(storeState.data) : storeState.data,
+  } as StoreState<TAccessl | TSelected>;
 }
 
 function areSameDesignEditor(designEditor: DesignEditorId, other: DesignEditorId): boolean {


### PR DESCRIPTION
Introduce error and loading boundaries to stores and remove all 'safe' hooks to simplify store usage and improve robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-611b2f7b-14b7-414f-a8f5-4d1cd585590c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-611b2f7b-14b7-414f-a8f5-4d1cd585590c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

